### PR TITLE
Update reqwest dependency to support newer OpenSSL versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Aaronepower/ddg.git"
 version = "0.5.0"
 
 [dependencies]
-reqwest = "0.8"
+reqwest = "0.9"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"


### PR DESCRIPTION
The current build fails to build on up-to-date Linux systems including the Ubuntu 18.10 distribution, because the OpenSSL library is too new.

This PR updates the `reqwest` dependency to the newest available version, to support newer OpenSSL versions.